### PR TITLE
Show users their own resources

### DIFF
--- a/client/src/components/ResourceList/ResourceList.test.js
+++ b/client/src/components/ResourceList/ResourceList.test.js
@@ -13,7 +13,7 @@ describe("ResourceList", () => {
 			title: "Data Binding in React",
 			url: "https://www.joshwcomeau.com/react/data-binding/",
 		});
-		render(<ResourceList resources={[resource]} />);
+		render(<ResourceList showMore={5} resources={[resource]} totalCount={1} />);
 		expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(
 			resource.title
 		);
@@ -28,20 +28,111 @@ describe("ResourceList", () => {
 		expect(screen.getByText(/no resources to show/i)).toBeInTheDocument();
 	});
 
-	it("shows a publish button if enabled", async () => {
+	it("shows a publish button on draft resource", async () => {
 		const publish = jest.fn();
-		const resource = resourceStub();
+		const resource = resourceStub({ draft: true });
 		const user = userEvent.setup();
-		render(<ResourceList publish={publish} resources={[resource]} />);
-
+		render(
+			<ResourceList publish={publish} resources={[resource]} totalCount={1} />
+		);
+		expect(
+			screen.getByRole("button", { name: /publish/i })
+		).toBeInTheDocument();
 		await user.click(screen.getByRole("button", { name: /publish/i }));
-
 		expect(publish).toHaveBeenCalledWith(resource.id);
 	});
 
 	it("shows the topic if available", () => {
 		const resource = resourceStub({ topic_name: "My Topic" });
-		render(<ResourceList resources={[resource]} />);
+		render(<ResourceList resources={[resource]} totalCount={1} />);
 		expect(screen.getByText(resource.topic_name)).toBeInTheDocument();
+	});
+
+	it("shows the Draft badge if available", async () => {
+		const resource = resourceStub({ draft: true });
+		render(
+			<ResourceList showBadge={true} resources={[resource]} totalCount={1} />
+		);
+		await expect(
+			screen.getByRole("heading", { name: /☐ Draft/i })
+		).toBeInTheDocument();
+	});
+
+	it("shows the Published badge if available", async () => {
+		const resource = resourceStub({
+			description:
+				"If a resource is published, the badge is display within the accounts page",
+			title: "Pulished Badge",
+			url: "https://www.ematembu.com",
+		});
+		render(
+			<ResourceList showBadge={true} resources={[resource]} totalCount={1} />
+		);
+		await expect(
+			screen.getByRole("heading", { name: /☑ Published/i })
+		).toBeInTheDocument();
+	});
+
+	it("shows the LoadMore button", async () => {
+		const resource = [
+			resourceStub({
+				description:
+					"If a resource is published, the badge is display within the accounts page",
+				title: "Pulished Badge",
+				url: "https://www.ematembu.com/",
+			}),
+			resourceStub({
+				description:
+					"If a resource is draft, the badge is display within the accounts page",
+				title: "Draft Badge",
+				url: "https://www.ematembu2.com/",
+			}),
+		];
+		const loadMore = await jest.fn();
+		const user = userEvent.setup();
+		render(
+			<ResourceList
+				loadMore={loadMore}
+				showMore={1}
+				showBadge={true}
+				resources={resource}
+				totalCount={2}
+			/>
+		);
+		expect(
+			screen.getByRole("button", { name: /Load More/i })
+		).toBeInTheDocument();
+		await user.click(screen.getByRole("button", { name: /Load More/i }));
+		expect(loadMore).toHaveBeenCalled();
+	});
+
+	it("shows the No More To Load button", async () => {
+		const resource = [
+			resourceStub({
+				description:
+					"If a resource is published, the badge is display within the accounts page",
+				title: "Pulished Badge",
+				url: "https://www.ematembu3.com/",
+			}),
+			resourceStub({
+				description:
+					"If a resource is suggested, the badge is display within the accounts page",
+				title: "Draft Badge",
+				url: "https://www.ematembu4.com/",
+			}),
+		];
+		const loadMore = await jest.fn();
+		render(
+			<ResourceList
+				loadMore={loadMore}
+				showMore={2}
+				showBadge={true}
+				resources={resource}
+				totalCount={2}
+			/>
+		);
+		expect(
+			screen.getByRole("button", { name: /No more to load/i })
+		).toBeInTheDocument();
 	});
 });

--- a/client/src/components/ResourceList/index.js
+++ b/client/src/components/ResourceList/index.js
@@ -5,12 +5,12 @@ import "./ResourceList.scss";
 export default function ResourceList({
 	showBadge = false,
 	loading = false,
-	totalCount = 0,
 	loadMore,
 	showMore,
 	publish,
 	resources,
 }) {
+	const totalCount = resources.length;
 	const noResource = totalCount === 0;
 	const exceedResource = showMore >= totalCount;
 	return (
@@ -65,7 +65,6 @@ ResourceList.propTypes = {
 	showBadge: PropTypes.bool,
 	loading: PropTypes.bool,
 	showMore: PropTypes.number,
-	totalCount: PropTypes.number,
 	loadMore: PropTypes.func,
 	publish: PropTypes.func,
 	resources: PropTypes.arrayOf(

--- a/client/src/components/ResourceList/index.js
+++ b/client/src/components/ResourceList/index.js
@@ -2,32 +2,71 @@ import PropTypes from "prop-types";
 
 import "./ResourceList.scss";
 
-export default function ResourceList({ publish, resources }) {
+export default function ResourceList({
+	showBadge = false,
+	loading = false,
+	totalCount = 0,
+	loadMore,
+	showMore,
+	publish,
+	resources,
+}) {
+	const noResource = totalCount === 0;
+	const exceedResource = showMore >= totalCount;
 	return (
 		<ul className="resource-list">
-			{resources.length === 0 && (
+			{noResource && (
 				<li className="no-resources">
 					<em>No resources to show.</em>
 				</li>
 			)}
-			{resources.map(({ description, id, title, topic_name, url }) => (
-				<li key={id}>
-					<div>
-						<h3>{title}</h3>
-						{topic_name && <span className="topic">{topic_name}</span>}
-					</div>
-					{description && <p className="resource-description">{description}</p>}
-					<div>
-						<a href={url}>{formatUrl(url)}</a>
-						{publish && <button onClick={() => publish(id)}>Publish</button>}
-					</div>
-				</li>
-			))}
+			{resources
+				?.slice(0, showMore ? showMore : totalCount)
+				.map(({ description, draft, id, title, topic_name, url }) => (
+					<li key={id}>
+						{showBadge ? (
+							draft ? (
+								<h4>&#x2610; Draft</h4>
+							) : (
+								<h4>&#x2611; Published</h4>
+							)
+						) : (
+							""
+						)}
+						<div>
+							<h3>{title}</h3>
+							{topic_name && <span className="topic">{topic_name}</span>}
+						</div>
+						{description && (
+							<p className="resource-description">{description}</p>
+						)}
+						<div>
+							<a href={url}>{formatUrl(url)}</a>
+							{publish && draft && (
+								<button onClick={() => publish(id)}>Publish</button>
+							)}
+						</div>
+					</li>
+				))}
+			{!noResource && showMore && (
+				<button onClick={loadMore} disabled={exceedResource ? "disabled" : ""}>
+					{loading
+						? "Loading..."
+						: exceedResource
+							? "No more to load"
+							: "Load More"}
+				</button>
+			)}
 		</ul>
 	);
 }
 
 ResourceList.propTypes = {
+	showBadge: PropTypes.bool,
+	loading: PropTypes.bool,
+	showMore: PropTypes.number,
+	totalCount: PropTypes.number,
+	loadMore: PropTypes.func,
 	publish: PropTypes.func,
 	resources: PropTypes.arrayOf(
 		PropTypes.shape({

--- a/client/src/pages/Account/Account.test.js
+++ b/client/src/pages/Account/Account.test.js
@@ -2,25 +2,37 @@ import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 import { usePrincipal } from "../../authContext";
+import { ResourceList } from "../../components";
 
 import Account from "./index";
 
 jest.mock("../../authContext");
+jest.mock("../../components/ResourceList/index");
 
 describe("Account", () => {
-	it("shows the user when available", () => {
-		const email = "bluepanda897@example.com";
-		const name = "Danitsja Mennink";
-		usePrincipal.mockReturnValue({ email, name });
-		render(<Account />);
+	const id = "c4f32c85-fd0a-4a3b-b5d5-42ca7ade19ec";
+	const email = "bluepanda897@example.com";
+	const name = "Danitsja Mennink";
+	it("shows the user when available with their resoure", () => {
+		usePrincipal.mockReturnValue({ id, name, email });
+		render(
+			<MemoryRouter initialEntries={["/account"]}>
+				<Account />
+			</MemoryRouter>
+		);
 		expect(screen.getByText(email)).toBeInTheDocument();
 		expect(screen.getByText(name)).toBeInTheDocument();
+		expect(screen.getByText("My Resources")).toBeInTheDocument();
+		expect(ResourceList).toHaveBeenCalled();
 	});
 
 	it("shows an alternative when email unavailable", () => {
-		const name = "Danitsja Mennink";
-		usePrincipal.mockReturnValue({ name });
-		render(<Account />);
+		usePrincipal.mockReturnValue({ id, name });
+		render(
+			<MemoryRouter initialEntries={["/account"]}>
+				<Account />
+			</MemoryRouter>
+		);
 		expect(screen.getByText("N/A")).toBeInTheDocument();
 		expect(screen.getByText(name)).toBeInTheDocument();
 	});
@@ -41,7 +53,11 @@ describe("Account", () => {
 
 	it("shows a logout link", () => {
 		usePrincipal.mockReturnValue({ email: "", name: "" });
-		render(<Account />);
+		render(
+			<MemoryRouter initialEntries={["/account"]}>
+				<Account />
+			</MemoryRouter>
+		);
 		const form = screen.getByRole("form");
 		expect(form).toHaveAttribute("action", "/api/auth/logout");
 		expect(form).toHaveAttribute("method", "POST");

--- a/client/src/pages/Account/index.js
+++ b/client/src/pages/Account/index.js
@@ -12,7 +12,7 @@ export default function Account() {
 	const principal = usePrincipal();
 	const userService = useService(UserService);
 	const resourceService = useService(ResourceService);
-	const [{ resources, totalCount } = {}, setEnvelope] = useState();
+	const [{ resources } = {}, setEnvelope] = useState();
 	const [loading, setLoading] = useState(false);
 	const [showMore, setShowMore] = useState(LIMIT);
 
@@ -73,7 +73,6 @@ export default function Account() {
 					loadMore={loadMore}
 					loading={loading}
 					publish={publish}
-					totalCount={totalCount}
 					resources={resources ?? []}
 				/>
 			</section>

--- a/client/src/pages/Account/index.js
+++ b/client/src/pages/Account/index.js
@@ -1,12 +1,43 @@
+import { useEffect, useState, useCallback } from "react";
 import { Navigate } from "react-router-dom";
 
 import { usePrincipal } from "../../authContext";
 import { Button } from "../../components";
-
+import { ResourceList } from "../../components";
+import { ResourceService, UserService, useService } from "../../services";
 import "./Account.scss";
 
 export default function Account() {
+	const LIMIT = 15;
 	const principal = usePrincipal();
+	const userService = useService(UserService);
+	const resourceService = useService(ResourceService);
+	const [{ resources, totalCount } = {}, setEnvelope] = useState();
+	const [loading, setLoading] = useState(false);
+	const [showMore, setShowMore] = useState(LIMIT);
+
+	const loadMore = () => {
+		setShowMore((prevResource) => prevResource + LIMIT);
+	};
+
+	const refreshResource = useCallback(async () => {
+		await userService.getByUser(principal?.id).then(setEnvelope);
+		setLoading(false);
+	}, [userService, principal]);
+
+	useEffect(() => {
+		userService.getByUser(principal?.id).then(setEnvelope);
+		setLoading(false);
+	}, [userService, principal]);
+
+	const publish = useCallback(
+		async (id) => {
+			await resourceService.publish(id);
+			await refreshResource();
+		},
+		[refreshResource, resourceService]
+	);
+
 	if (!principal) {
 		return <Navigate to="/" />;
 	}
@@ -34,6 +65,18 @@ export default function Account() {
 					Log out
 				</Button>
 			</form>
+			<h2>My Resources</h2>
+			<section>
+				<ResourceList
+					showBadge={true}
+					showMore={showMore}
+					loadMore={loadMore}
+					loading={loading}
+					publish={publish}
+					totalCount={totalCount}
+					resources={resources ?? []}
+				/>
+			</section>
 		</>
 	);
 }

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -4,6 +4,7 @@ import { useAuthenticatedFetch } from "../authContext";
 
 export { default as ResourceService } from "./resourceService";
 export { default as TopicService } from "./topicService";
+export { default as UserService } from "./userService";
 
 /**
  * Inject the authenticated fetch wrapper into the specified service.

--- a/client/src/services/userService.js
+++ b/client/src/services/userService.js
@@ -1,0 +1,23 @@
+export default class UserService {
+	static ENDPOINT = "/api/users";
+
+	constructor(request = fetch) {
+		this.fetch = request;
+	}
+
+	async getByUser(id) {
+		const res = await this.fetch(`${UserService.ENDPOINT}/${id}`);
+		if (res.ok) {
+			const { resources, ...rest } = await res.json();
+			return { ...rest, resources: resources.map(this._revive.bind(this)) };
+		}
+	}
+
+	_revive({ accession, publication, ...resource }) {
+		return {
+			...resource,
+			accession: accession && new Date(accession),
+			publication: publication && new Date(publication),
+		};
+	}
+}

--- a/client/src/services/userService.js
+++ b/client/src/services/userService.js
@@ -1,3 +1,5 @@
+import { Navigate } from "react-router";
+
 export default class UserService {
 	static ENDPOINT = "/api/users";
 
@@ -6,10 +8,14 @@ export default class UserService {
 	}
 
 	async getByUser(id) {
-		const res = await this.fetch(`${UserService.ENDPOINT}/${id}`);
-		if (res.ok) {
-			const { resources, ...rest } = await res.json();
-			return { ...rest, resources: resources.map(this._revive.bind(this)) };
+		try {
+			const res = await this.fetch(`${UserService.ENDPOINT}/${id}`);
+			if (res.ok) {
+				const { resources, ...rest } = await res.json();
+				return { ...rest, resources: resources.map(this._revive.bind(this)) };
+			}
+		} catch {
+			return <Navigate to={"/"} />;
 		}
 	}
 

--- a/client/src/services/userService.test.js
+++ b/client/src/services/userService.test.js
@@ -1,0 +1,30 @@
+import { resourceStub } from "../../setupTests";
+
+import UserService from "./userService";
+
+describe("UserService", () => {
+	const service = new UserService();
+	const user = {
+		id: "ef87091b-0d08-4a18-81a1-3df0d6e663d1",
+		email: "ematembu2@gmail.com",
+		github_id: 50827537,
+		name: "Matembu Emmanuel Dominic",
+		is_admin: true,
+	};
+
+	describe("getByUser", () => {
+		it("returns user resources on success", async () => {
+			const getByUser = (UserService.prototype.getByUser = jest.fn());
+			getByUser.mockReturnValue({
+				user,
+				resources: resourceStub,
+				totalCount: resourceStub.length,
+			});
+			const resource = service.getByUser(
+				"ef87091b-0d08-4a18-81a1-3df0d6e663d1"
+			);
+			expect(resource.resources).toEqual(resourceStub);
+			expect(service.getByUser).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/client/src/services/userService.test.js
+++ b/client/src/services/userService.test.js
@@ -2,6 +2,8 @@ import { resourceStub } from "../../setupTests";
 
 import UserService from "./userService";
 
+jest.mock("./userService");
+
 describe("UserService", () => {
 	const service = new UserService();
 	const user = {
@@ -14,8 +16,7 @@ describe("UserService", () => {
 
 	describe("getByUser", () => {
 		it("returns user resources on success", async () => {
-			const getByUser = (UserService.prototype.getByUser = jest.fn());
-			getByUser.mockReturnValue({
+			UserService.prototype.getByUser.mockReturnValue({
 				user,
 				resources: resourceStub,
 				totalCount: resourceStub.length,
@@ -25,6 +26,14 @@ describe("UserService", () => {
 			);
 			expect(resource.resources).toEqual(resourceStub);
 			expect(service.getByUser).toHaveBeenCalledTimes(1);
+		});
+
+		it("should handle a failed on get user resources", async () => {
+			UserService.prototype.getByUser.mockImplementation(() =>
+				Promise.reject(new Error("Failed to fetch data"))
+			);
+			const resp = service.getByUser("ef87091b-0d08-4a18-81a1-3df0d6e663d1");
+			await expect(resp).rejects.toThrow("Failed to fetch data");
 		});
 	});
 });

--- a/e2e/integration/account.test.js
+++ b/e2e/integration/account.test.js
@@ -18,6 +18,8 @@ it("lets the user log out", () => {
 it("shows the authenticated user's resource", () => {
 	const title = "User resource item";
 	const url = "https://example.com";
+	const draft = "☐ Draft";
+	cy.seed("admin");
 	cy.visit("/");
 	cy.logInAs("admin@codeyourfuture.io");
 	cy.findByRole("link", { name: /suggest/i }).click();
@@ -25,9 +27,19 @@ it("shows the authenticated user's resource", () => {
 	cy.findByRole("textbox", { name: /url/i }).type(`${url}{enter}`);
 	cy.findByText(/thank you for suggesting a resource/i).should("exist");
 	cy.findByRole("link", { name: /account/i }).click();
-	cy.findByRole("heading", { level: 2 }).should("contain.text", "My Resources");
-	cy.findByRole("textbox", { name: /title/i }).should("have.value", title);
-	cy.findByRole("textbox", { name: /url/i }).should("have.value", url);
-	cy.findByRole("heading", { level: 4 }).should("contain.text", "☐ Draft");
-	cy.findByRole("button", { name: /No more to load/i }).should("exist");
+	cy.findByRole("heading", { level: 2, name: "My Resources" })
+		.should("be.visible")
+		.should("contain.text", "My Resources");
+	cy.findByRole("heading", { level: 3, name: title })
+		.should("exist")
+		.should("contain", title);
+	cy.findByRole("link", { name: url.slice(8) })
+		.should("exist")
+		.should("contain", url.slice(8));
+	cy.findByRole("heading", { level: 4, name: draft })
+		.should("exist")
+		.should("contain", draft);
+	cy.findByRole("button", { name: /No more to load/i })
+		.should("be.visible")
+		.should("exist");
 });

--- a/e2e/integration/account.test.js
+++ b/e2e/integration/account.test.js
@@ -14,3 +14,20 @@ it("lets the user log out", () => {
 	cy.findByRole("button", { name: /log out/i }).click();
 	cy.findByRole("link", { name: /log in/i }).should("exist");
 });
+
+it("shows the authenticated user's resource", () => {
+	const title = "User resource item";
+	const url = "https://example.com";
+	cy.visit("/");
+	cy.logInAs("admin@codeyourfuture.io");
+	cy.findByRole("link", { name: /suggest/i }).click();
+	cy.findByRole("textbox", { name: /title/i }).type(title);
+	cy.findByRole("textbox", { name: /url/i }).type(`${url}{enter}`);
+	cy.findByText(/thank you for suggesting a resource/i).should("exist");
+	cy.findByRole("link", { name: /account/i }).click();
+	cy.findByRole("heading", { level: 2 }).should("contain.text", "My Resources");
+	cy.findByRole("textbox", { name: /title/i }).should("have.value", title);
+	cy.findByRole("textbox", { name: /url/i }).should("have.value", url);
+	cy.findByRole("heading", { level: 4 }).should("contain.text", "☐ Draft");
+	cy.findByRole("button", { name: /No more to load/i }).should("exist");
+});

--- a/server/docs/users.yml
+++ b/server/docs/users.yml
@@ -18,6 +18,37 @@
         $ref: "#/components/responses/InternalServerError"
 
 /users/{id}:
+  get:
+    tags: [Users]
+    description: |
+      Get user's resources by source equal to parameter id.
+
+      **Note**: Published resources, belonging to the authenticated user, are available to all users; drafts are only accessible to admin users.
+    security:
+      - sudoToken: []
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    requestBody:
+      required: false
+    responses:
+      200:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PaginatedResources"
+      400:
+        $ref: "#/components/responses/BadRequestError"
+      401:
+        $ref: "#/components/responses/UnauthorizedError"
+      404:
+        $ref: "#/components/responses/NotFoundRequestError"
+      500:
+        $ref: "#/components/responses/InternalServerError"
   patch:
     tags: [Users]
     description: |

--- a/server/users/usersController.js
+++ b/server/users/usersController.js
@@ -5,6 +5,7 @@ import {
 	asyncHandler,
 	methodNotAllowed,
 	sudoOnly,
+	authOnly,
 	validated,
 } from "../utils/middleware";
 
@@ -25,6 +26,26 @@ router
 
 router
 	.route("/:id")
+	.get(
+		authOnly,
+		asyncHandler(async (req, res) => {
+			try {
+				const user = await service.getById(req.params?.id);
+				const { is_admin: isAdmin = false } = req.user ?? {};
+				if (!req.user) {
+					return res.sendStatus(401);
+				}
+				res.send(
+					await service.getMine({ source: req.params?.id, user, isAdmin })
+				);
+			} catch (err) {
+				if (err instanceof MissingUser) {
+					return res.sendStatus(404);
+				}
+				throw err;
+			}
+		})
+	)
 	.patch(
 		sudoOnly,
 		validated({

--- a/server/users/usersService.js
+++ b/server/users/usersService.js
@@ -30,3 +30,16 @@ export async function promote(id) {
 	await getById(id);
 	return await repository.update(id, { is_admin: true });
 }
+
+export async function getMine({ source, user, isAdmin }) {
+	const userResources = await repository.findMine({
+		source,
+		isAdmin,
+	});
+	const totalCount = userResources.length;
+	return {
+		user,
+		resources: userResources,
+		totalCount,
+	};
+}


### PR DESCRIPTION
This is a:

<!-- Tick one category - if more than one applies, it should be split up -->

- [x] ✨ **New feature** - new behaviour has been implemented
- [ ] 🐛 **Bug fix** - existing behaviour has been made to behave
- [ ] ♻️ **Refactor** - the behaviour has not changed, just the implementation
- [ ] ✅ **Test backfill** - tests for existing behaviour were added but the behaviour itself hasn't changed
- [ ] ⚙️ **Chore** - maintenance task, behaviour and implementation haven't changed

<!-- adapted from https://gitmoji.dev/ -->

### Description
- [x] When you log into the application while you have published resources, navigate to the accounts page to view your personal resources, while as an administrator, you will see your personal published and draft resources.
- [x] Users are able to view their published resources when logged in as normal authenticated users while admins can also see draft resources.
<!-- Describe what merging this pull request will do -->

- **Purpose** - <!-- Allow astronauts to perform a case-insensitive search for their spaceship. -->
- [x] Users can see the resources they suggested without having to search through the entire list of resources in the application.
<!-- Describe how the reviewer should check it works -->

- **How to check** - <!-- Log in as an astronaut, go to the Spaceships tab and type "saturn" into the search box. Previously Saturn V would not have appeared, due to the capital S, but now it does. -->
- [x] Login into the application.
- [x] Write some suggestions to be published yet if you have logged in as an admin
- [x] If you're an admin, you will be able to see a list of your published resources as well as your draft resources on the account page.
- [x] If you're a normal authenticated user, you will see only the published resources.
### Links
- [x] resolve #12 
<!-- links to other issues/PRs/tickets, e.g. user/repo#123 -->

### Author checklist

<!-- All PRs -->

- [x] I have written a title that reflects the relevant ticket
- [x] I have written a description that says what the PR does and how to validate it
- [x] I have linked to the project board ticket (and any related PRs/issues) in the Links section
- [x] I have added a link to this PR to the ticket
- [x] I have made the PR to `main` from a branch named `feature/show-users-resource`
- [x] I have manually tested that the app still works correctly
- [x] I have requested reviewers here and in my team chat channel
<!-- depending on the task, the following may be optional -->
- [ ] I have spoken with my PM or TL about any parts of this task that may have become out-of-scope, or any additional improvements that I now realise may benefit my project
- [x] I have added tests, or new tests were not required
- [x] I have updated any documentation (e.g. diagrams, schemas), or documentation updates were not required
