### PR TITLE
Migrate PATCH requests to JSON Patch format

### DIFF
--- a/client/src/services/resourceService.js
+++ b/client/src/services/resourceService.js
@@ -32,8 +32,8 @@ export default class ResourceService {
 
 	async publish(id) {
 		const res = await this.fetch(`${ResourceService.ENDPOINT}/${id}`, {
-			body: JSON.stringify({ draft: false }),
-			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify([{ op: "replace", path: "/draft", value: false }]),
+			headers: { "Content-Type": "application/json-patch+json" },
 			method: "PATCH",
 		});
 		if (res.ok) {

--- a/client/src/services/resourceService.test.js
+++ b/client/src/services/resourceService.test.js
@@ -82,6 +82,7 @@ describe("ResourceService", () => {
 
 	describe("publish", () => {
 		it("sends an appropriate PATCH request", async () => {
+			/** @type {Request} */
 			let request;
 			const id = "abc123";
 			server.use(
@@ -92,7 +93,12 @@ describe("ResourceService", () => {
 			);
 			await service.publish(id);
 			expect(new URL(request.url).pathname).toMatch(new RegExp(`/${id}$`));
-			await expect(request.json()).resolves.toEqual({ draft: false });
+			expect(request.headers.get("Content-Type")).toBe(
+				"application/json-patch+json"
+			);
+			await expect(request.json()).resolves.toEqual([
+				{ op: "replace", path: "/draft", value: false },
+			]);
 		});
 	});
 

--- a/e2e/integration/suggest.test.js
+++ b/e2e/integration/suggest.test.js
@@ -31,7 +31,7 @@ it("lets an authenticated user suggest a resource", () => {
 			expect(submitted).to.have.property("title", title);
 			expect(submitted).to.have.property("url", url);
 			cy.request({
-				body: { draft: false },
+				body: [{ op: "replace", path: "/draft", value: false }],
 				headers: { Authorization: `Bearer ${Cypress.env("SUDO_TOKEN")}` },
 				method: "PATCH",
 				url: `/api/resources/${created.id}`,

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -11,6 +11,7 @@
 						"assertFunctionNames": [
 							"expect",
 							"agent.**.expect",
+							"*Agent.**.expect",
 							"request.**.expect",
 							"screen.findBy*"
 						]

--- a/server/app.js
+++ b/server/app.js
@@ -25,7 +25,7 @@ const sessionConfig = {
 
 const app = express();
 
-app.use(express.json());
+app.use(express.json({ type: ["application/json", "application/*+json"] }));
 app.use(express.urlencoded({ extended: true }));
 
 app.use(configuredHelmet());

--- a/server/docs/resources.yml
+++ b/server/docs/resources.yml
@@ -82,16 +82,7 @@
           type: string
           format: uuid
     requestBody:
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            required: [draft]
-            properties:
-              draft:
-                type: boolean
-                example: false
+      $ref: "#/components/requests/JsonPatch"
     responses:
       200:
         content:
@@ -104,5 +95,7 @@
         $ref: "#/components/responses/UnauthorizedError"
       404:
         $ref: "#/components/responses/NotFoundError"
+      422:
+        $ref: "#/components/responses/UnprocessableContent"
       500:
         $ref: "#/components/responses/InternalServerError"

--- a/server/docs/schema.yml
+++ b/server/docs/schema.yml
@@ -12,6 +12,14 @@ tags:
       url: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#web-application-flow
 
 components:
+  requests:
+    JsonPatch:
+      required: true
+      content:
+        application/json-patch+json:
+          schema:
+            $ref: "#/components/schemas/JsonPatch"
+
   responses:
     BadRequestError:
       description: The request was not accepted.
@@ -59,6 +67,20 @@ components:
           schema:
             type: string
             example: Unauthorized
+    UnprocessableContent:
+      description: The request was well-formed but could not be processed
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [details, error]
+            properties:
+              details:
+                example: Only changing the draft status to false is supported
+                type: string
+              error:
+                enum:
+                  - Unprocessable Content
 
   schemas:
     BaseResource:
@@ -98,6 +120,27 @@ components:
             topic_name:
               type: string
               example: "HTML/CSS"
+    JsonPatch:
+      description: |
+        [JSON Patch](https://jsonpatch.com/) is a format for describing changes to a JSON document.
+        It can be used to avoid sending a whole document when only a part has changed.
+
+        Described by [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902/).
+      type: array
+      items:
+        schema: object
+        required: [op, path]
+        properties:
+          op:
+            type: string
+            enum: [add, copy, move, remove, replace, test]
+          path:
+            type: string
+          from:
+            type: string
+          value:
+            description: Can be anything
+            nullable: true
     PublishedResource:
       allOf:
         - $ref: "#/components/schemas/BaseResource"

--- a/server/docs/users.yml
+++ b/server/docs/users.yml
@@ -34,16 +34,7 @@
           type: string
           format: uuid
     requestBody:
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            required: ["is_admin"]
-            properties:
-              is_admin:
-                type: boolean
-                example: true
+      $ref: "#/components/requests/JsonPatch"
     responses:
       200:
         content:
@@ -54,5 +45,7 @@
         $ref: "#/components/responses/BadRequestError"
       401:
         $ref: "#/components/responses/UnauthorizedError"
+      422:
+        $ref: "#/components/responses/UnprocessableContent"
       500:
         $ref: "#/components/responses/InternalServerError"

--- a/server/setupTests.js
+++ b/server/setupTests.js
@@ -111,6 +111,7 @@ export const authenticateAs = async (identity) => {
 			.patch(`/api/users/${user.id}`)
 			.set("Authorization", `Bearer ${sudoToken}`)
 			.set("User-Agent", "supertest")
+			.send([{ op: "replace", path: "/is_admin", value: true }])
 			.expect(200));
 	}
 	return { agent, user };

--- a/server/utils/validators.js
+++ b/server/utils/validators.js
@@ -1,0 +1,14 @@
+import { Joi } from "express-validation";
+
+export const jsonPatch = Joi.array()
+	.min(1)
+	.items(
+		Joi.object({
+			op: Joi.string()
+				.valid("add", "copy", "move", "remove", "replace", "test")
+				.required(),
+			path: Joi.string().required(),
+			from: Joi.string(),
+			value: Joi.any(),
+		})
+	);


### PR DESCRIPTION
This is a:

<!-- Tick one category - if more than one applies, it should be split up -->

- [ ] ✨ **New feature** - new behaviour has been implemented
- [ ] 🐛 **Bug fix** - existing behaviour has been made to behave
- [x] ♻️ **Refactor** - the behaviour has not changed, just the implementation
- [ ] ✅ **Test backfill** - tests for existing behaviour were added but the behaviour itself hasn't changed
- [ ] ⚙️ **Chore** - maintenance task, behaviour and implementation haven't changed

<!-- adapted from https://gitmoji.dev/ -->

### Description

<!-- Describe what merging this pull request will do -->

- **Purpose** - using [JSON Patch](https://jsonpatch.com/) format for PATCH request bodies means we're using a standardised structure and allows more flexibility in functionality

<!-- Describe how the reviewer should check it works -->

- **How to check** - <!-- Log in as an astronaut, go to the Spaceships tab and type "saturn" into the search box. Previously Saturn V would not have appeared, due to the capital S, but now it does. -->
    - Ensure publishing a draft resource still works (this is the only UI functionality that uses a PATCH)
    - Ensure a user can still be promoted to admin using a SUDO token via `PATCH /api/users/:id` (not in UI, use e.g. cURL/Postman)

### Links

<!-- links to other issues/PRs/tickets, e.g. user/repo#123 -->

### Author checklist

<!-- All PRs -->

- [ ] ~I have written a title that reflects the relevant ticket~
- [x] I have written a description that says what the PR does and how to validate it
- [ ] ~I have linked to the project board ticket (and any related PRs/issues) in the Links section~
- [ ] ~I have added a link to this PR to the ticket~
- [x] I have made the PR to `main` from a branch named `<category>/<name>`, e.g. `feature/edit-spaceships` or `bugfix/restore-oxygen`
- [x] I have manually tested that the app still works correctly
- [ ] ~I have requested reviewers here and in my team chat channel~
<!-- depending on the task, the following may be optional -->
- [ ] ~I have spoken with my PM or TL about any parts of this task that may have become out-of-scope, or any additional improvements that I now realise may benefit my project~
- [x] I have added tests, or new tests were not required
- [x] I have updated any documentation (e.g. diagrams, schemas), or documentation updates were not required
